### PR TITLE
feat: implement `Reactor` and `ThreadPool`

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -1,18 +1,18 @@
 use mio::{Interest, event::Event};
 
-pub trait Eventhandler {
+pub trait EventHandler {
     fn handle_event(&self, event: &Event);
 }
 
 pub struct HandlerEntry {
-    pub handler: Box<dyn Eventhandler + Send + Sync>,
+    pub handler: Box<dyn EventHandler + Send + Sync>,
     pub interest: Interest,
 }
 
 impl HandlerEntry {
     pub fn new<H>(handler: H, interest: Interest) -> Self
     where
-        H: Eventhandler + Send + Sync + 'static,
+        H: EventHandler + Send + Sync + 'static,
     {
         HandlerEntry {
             handler: Box::new(handler),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod poll;
 pub mod handler;
+pub mod thread_pool;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod poll;
 pub mod handler;
 pub mod thread_pool;
+pub mod reactor;

--- a/src/poll.rs
+++ b/src/poll.rs
@@ -1,17 +1,18 @@
 // TODO: add custom error module and use it here
+use mio::{Events, Interest, Poll, Token};
 use std::{
     collections::HashMap,
     error::Error,
-    sync::{Arc, Mutex},
+    sync::{Arc, RwLock},
 };
 
-use mio::{Events, Interest, Poll, Token};
+use crate::handler::{EventHandler, HandlerEntry};
 
-use crate::handler::{Eventhandler, HandlerEntry};
+type Registry = Arc<RwLock<HashMap<Token, HandlerEntry>>>;
 
 pub struct PollHandle {
     poller: mio::Poll,
-    registery: Arc<Mutex<HashMap<Token, HandlerEntry>>>,
+    registery: Registry,
     waker: Arc<mio::Waker>,
 }
 
@@ -19,8 +20,7 @@ impl PollHandle {
     pub fn new() -> Result<Self, Box<dyn Error>> {
         let poller = Poll::new()?;
         let waker = mio::Waker::new(poller.registry(), Token(0))?;
-        let registery: Arc<Mutex<HashMap<Token, HandlerEntry>>> =
-            Arc::new(Mutex::new(HashMap::new()));
+        let registery: Registry = Arc::new(RwLock::new(HashMap::new()));
         Ok(PollHandle {
             poller,
             registery,
@@ -36,29 +36,29 @@ impl PollHandle {
         handler: H,
     ) -> Result<(), Box<dyn Error>>
     where
-        H: Eventhandler + Send + Sync + 'static,
+        H: EventHandler + Send + Sync + 'static,
         S: mio::event::Source + ?Sized,
     {
         src.register(self.poller.registry(), token, interest)?;
 
-        match self.registery.lock() {
+        match self.registery.write() {
             Ok(mut registery) => {
                 registery.insert(token, HandlerEntry::new(handler, interest));
             }
             Err(_) => {
-                return Err("Failed to lock registery".into());
+                return Err("Failed to write lock registery".into());
             }
         }
         Ok(())
     }
 
     pub fn unregister(&self, token: Token) -> Result<(), Box<dyn Error>> {
-        match self.registery.lock() {
+        match self.registery.write() {
             Ok(mut registery) => {
                 registery.remove(&token);
             }
             Err(_) => {
-                return Err("Failed to lock registery".into());
+                return Err("Failed to write lock registery".into());
             }
         }
         Ok(())
@@ -75,6 +75,10 @@ impl PollHandle {
 
     pub fn wake(&self) -> Result<(), Box<dyn Error>> {
         Ok(self.waker.wake()?)
+    }
+
+    pub fn get_registery(&self) -> Registry {
+        self.registery.clone()
     }
 }
 
@@ -141,7 +145,7 @@ mod tests {
             called: Arc<AtomicBool>,
         }
 
-        impl Eventhandler for TestHandler {
+        impl EventHandler for TestHandler {
             fn handle_event(&self, _event: &mio::event::Event) {
                 self.called.store(true, Ordering::SeqCst);
             }
@@ -159,7 +163,7 @@ mod tests {
         );
 
         assert!(
-            poller.registery.lock().unwrap().contains_key(&token),
+            poller.registery.read().unwrap().contains_key(&token),
             "Token not found in registry"
         );
 
@@ -169,7 +173,7 @@ mod tests {
         );
 
         assert!(
-            !poller.registery.lock().unwrap().contains_key(&token),
+            !poller.registery.read().unwrap().contains_key(&token),
             "Token should have been removed from registry"
         );
     }
@@ -181,7 +185,7 @@ mod tests {
         let mut src2 = TestSource::new();
 
         struct NoopHandler;
-        impl Eventhandler for NoopHandler {
+        impl EventHandler for NoopHandler {
             fn handle_event(&self, _event: &mio::event::Event) {}
         }
 
@@ -198,7 +202,7 @@ mod tests {
             "Failed to register src2"
         );
 
-        let registry = poller.registery.lock().unwrap();
+        let registry = poller.registery.read().unwrap();
         assert_eq!(registry.len(), 2);
         assert!(registry.contains_key(&Token(1)), "Failed to find src1");
         assert!(registry.contains_key(&Token(2)), "Failed to find src2");

--- a/src/reactor.rs
+++ b/src/reactor.rs
@@ -1,0 +1,69 @@
+use std::{
+    error::Error,
+    sync::atomic::{AtomicBool, Ordering},
+    time::Duration,
+};
+
+use crate::{poll::PollHandle, thread_pool::ThreadPool};
+use mio::{Events, event::Event};
+
+const EVENTS_CAPACITY: usize = 1024;
+const POLL_TIMEOUT_MS: u64 = 150;
+
+pub struct Reactor {
+    poll_handle: PollHandle,
+    events: Events,
+    pool: ThreadPool,
+    running: AtomicBool,
+}
+
+impl Reactor {
+    pub fn new(pool_size: usize) -> Result<Self, Box<dyn Error>> {
+        Ok(Self {
+            poll_handle: PollHandle::new()?,
+            events: Events::with_capacity(EVENTS_CAPACITY),
+            pool: ThreadPool::new(pool_size),
+            running: AtomicBool::new(false),
+        })
+    }
+
+    pub fn run(&mut self) -> Result<(), Box<dyn Error>> {
+        self.running.store(true, Ordering::SeqCst);
+
+        while self.running.load(Ordering::SeqCst) {
+            println!("{}", self.running.load(Ordering::SeqCst));
+            let _ = self.poll_handle.poll(
+                &mut self.events,
+                Some(Duration::from_millis(POLL_TIMEOUT_MS)),
+            )?;
+
+            for event in self.events.iter() {
+                self.dispatch_event(event.clone())?;
+            }
+        }
+        Ok(())
+    }
+
+    pub fn shutdown(&self) {
+        self.running.store(false, Ordering::SeqCst);
+        self.poll_handle.wake().unwrap();
+    }
+
+    pub fn dispatch_event(&self, event: Event) -> Result<(), Box<dyn Error>> {
+        let token = event.token();
+
+        let registry = self.poll_handle.get_registery();
+
+        self.pool.exec(move || {
+            let registry = registry.read().unwrap();
+
+            if let Some(entry) = registry.get(&token) {
+                if (entry.interest.is_readable() && event.is_readable())
+                    || (entry.interest.is_writable() && event.is_writable())
+                {
+                    entry.handler.handle_event(&event);
+                }
+            }
+        })
+    }
+}


### PR DESCRIPTION
Implements the thread pool and reactor pattern, which closes #3 and also closes #4, as they're part of the event loop implementation.